### PR TITLE
Laravel 5 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: php
 php:
   - 5.5
   - 5.6
-  - hhvm
+
+before_install: echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Provides an solution for authentication users with LDAP for Laravel 5.x. It uses
 1. Change the authentication driver in the Laravel config to use the ldap driver. You can find this in the following file `config/auth.php`
 
     ```php
-    'driver' => 'ldap',
+    'providers' => [
+        'users' => [
+            'driver' => 'ldap',
+        ],
+    ],
     ```
 1. Publish a new configuration file with `php artisan vendor:publish` in the configuration folder of Laravel you will find `config/ldap.php` and modify to your needs. For more detail of the configuration you can always check on [ADLAP documentation](http://adldap.sourceforge.net/wiki/doku.php?id=documentation_configuration)
     
@@ -62,7 +66,26 @@ By default `App\Http\Controllers\Auth\AuthController` checks for the `email` fie
 protected $username = 'username';
 ```
 
-Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/master/authentication#authentication-quickstart)
+When you're using `php artisan make:auth` Laravel will create some default views out of the box. If you want to use them with Ldap-connector just change the `email` field to `username` in the following file `resources/views/auth/login.blade.php`
+
+Example:
+```html
+<div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
+    <label class="col-md-4 control-label">Username</label>
+
+    <div class="col-md-6">
+        <input type="text" class="form-control" name="username" value="{{ old('username') }}">
+
+        @if ($errors->has('username'))
+            <span class="help-block">
+                <strong>{{ $errors->first('username') }}</strong>
+            </span>
+        @endif
+    </div>
+</div>
+```
+
+For more information about the Authentication you can use the Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/master/authentication#authentication-quickstart)
 
 ### Ldap Groups
 - `Auth::user()->getGroups()` returns `array` with groups the current user belongs to. 
@@ -73,3 +96,6 @@ Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/maste
 - `Auth::user()->getFirstname()` returns authenticated first name.
 - `Auth::user()->getLastname()` returns authenticated last name.
 - `Auth::user()->getEmail()` returns authenticated email address.
+
+## Contributing
+Feel free to contribute to this project for new features or bug fixes. We are open for improvements!

--- a/README.md
+++ b/README.md
@@ -4,27 +4,28 @@
 [![Total Downloads](https://poser.pugx.org/dsdevbe/ldap-connector/downloads)](https://packagist.org/packages/dsdevbe/ldap-connector)
 [![License](https://poser.pugx.org/dsdevbe/ldap-connector/license)](https://packagist.org/packages/dsdevbe/ldap-connector)
 
-Provides an solution for authentication users with LDAP for Laravel 5.x. It uses ADLDAP 4.0 library forked on [Adldap2](https://github.com/Adldap2/Adldap2) to create a bridge between Laravel and LDAP
+Provides an solution for authentication users with LDAP for Laravel 5.x. It uses ADLDAP library on [Adldap2](https://github.com/Adldap2/Adldap2) to create a bridge between Laravel and LDAP
 
 ## Installation
-1. Install this package through Composer for Laravel v5.x:
+- [Laravel 5.1 - 5.0](#laravel-51---50)
+- [Laravel 5.2 - ...](#laravel-52---)
+
+## Laravel 5.1 - 5.0
+1. Install this package through Composer
     ```js
-    composer require dsdevbe/ldap-connector:3.*
+    composer require dsdevbe/3.*
     ```
     
 1. Add the service provider in the app configuration by opening `config/app.php`, and add a new item to the providers array.
        
-       ```
-       Dsdevbe\LdapConnector\LdapConnectorServiceProvider::class
-       ```
+    ```
+    Dsdevbe\LdapConnector\LdapConnectorServiceProvider::class
+    ```
+    
 1. Change the authentication driver in the Laravel config to use the ldap driver. You can find this in the following file `config/auth.php`
 
     ```php
-    'providers' => [
-        'users' => [
-            'driver' => 'ldap',
-        ],
-    ],
+    'driver' => 'ldap',
     ```
 1. Publish a new configuration file with `php artisan vendor:publish` in the configuration folder of Laravel you will find `config/ldap.php` and modify to your needs. For more detail of the configuration you can always check on [ADLAP documentation](http://adldap.sourceforge.net/wiki/doku.php?id=documentation_configuration)
     
@@ -47,7 +48,7 @@ Provides an solution for authentication users with LDAP for Laravel 5.x. It uses
     
     Please note that the fields 'admin_username' and 'admin_password' are required for session persistance!
     
-## Usage
+### Usage 
 The LDAP plugin is an extension of the Auth class and will act the same as normal usage with Eloquent driver.
     
 ```php
@@ -66,26 +67,7 @@ By default `App\Http\Controllers\Auth\AuthController` checks for the `email` fie
 protected $username = 'username';
 ```
 
-When you're using `php artisan make:auth` Laravel will create some default views out of the box. If you want to use them with Ldap-connector just change the `email` field to `username` in the following file `resources/views/auth/login.blade.php`
-
-Example:
-```html
-<div class="form-group{{ $errors->has('username') ? ' has-error' : '' }}">
-    <label class="col-md-4 control-label">Username</label>
-
-    <div class="col-md-6">
-        <input type="text" class="form-control" name="username" value="{{ old('username') }}">
-
-        @if ($errors->has('username'))
-            <span class="help-block">
-                <strong>{{ $errors->first('username') }}</strong>
-            </span>
-        @endif
-    </div>
-</div>
-```
-
-For more information about the Authentication you can use the Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/master/authentication#authentication-quickstart)
+Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/master/authentication#authentication-quickstart)
 
 ### Ldap Groups
 - `Auth::user()->getGroups()` returns `array` with groups the current user belongs to. 
@@ -96,6 +78,70 @@ For more information about the Authentication you can use the Laravel documentat
 - `Auth::user()->getFirstname()` returns authenticated first name.
 - `Auth::user()->getLastname()` returns authenticated last name.
 - `Auth::user()->getEmail()` returns authenticated email address.
+
+## Laravel 5.2 - ...
+1. Install this package through Composer
+    ```js
+    composer require dsdevbe/4.0.*
+    ```
+    
+1. Add the service provider in the app configuration by opening `config/app.php`, and add a new item to the providers array.
+       
+    ```
+    Dsdevbe\LdapConnector\LdapConnectorServiceProvider::class
+    ```
+    
+1. Change the authentication driver in the Laravel config to use the ldap driver. You can find this in the following file `config/auth.php`
+
+    ```php
+    'providers' => [
+        'users' => [
+            'driver' => 'ldap',
+            'adldap' => [
+                'account_suffix'=>  '@domain.local',
+                'domain_controllers'=>  array(
+                    '192.168.0.1',
+                    'dc02.domain.local'
+                ), // Load balancing domain controllers
+                'base_dn'   =>  'DC=domain,DC=local',
+                'admin_username' => 'admin', // This is required for session persistance in the application
+                'admin_password' => 'yourPassword',
+            ],
+        ],
+    ],
+    ```
+    Please note that the fields 'admin_username' and 'admin_password' are required for session persistance!
+    
+### Usage 
+The LDAP plugin is an extension of the Auth class and will act the same as normal usage with Eloquent driver.
+    
+```php
+if (Auth::attempt(array('username' => $username, 'password' => $password)))
+{
+    return Redirect::intended('dashboard');
+}
+```
+You can find more examples on [Laravel Auth Documentation](http://laravel.com/docs/master/authentication) on using the `Auth::` function.
+
+### Use AuthController
+If you want to use the authentication controller that ships with Laravel you will need to change the following files.
+By default `App\Http\Controllers\Auth\AuthController` checks for the `email` field if nothing is provided. To overwrite this value add the following line in the `AuthController`.
+
+```php
+protected $username = 'username';
+```
+
+Laravel documentation: [Authentication Quickstart](http://laravel.com/docs/master/authentication#authentication-quickstart)
+
+### Ldap User Information
+Difference with ldap-connector V3 is that now the adLDAP model is directly exposed on the user model. This means that you can fetch all data directly from the user.
+To access the adldap model you can use now `Auth::user()->getAdLDAP()`.
+
+Examples:
+- `Auth::user()->getAdLDAP()->getAccountName()`
+- `Auth::user()->getAdLDAP()->getFirstName()`
+
+To fetch more properties please check [adLDAP2 documentation](https://github.com/Adldap2/Adldap2/blob/v5.2/docs/models/USER.md)
 
 ## Contributing
 Feel free to contribute to this project for new features or bug fixes. We are open for improvements!

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.9",
         "laravel/framework": "~5.0",
         "adldap2/adldap2": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,9 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "ext-ldap": "*",
         "laravel/framework": "~5.0",
-        "adldap2/adldap2": "^4.0"
+        "adldap2/adldap2": "5.2.*"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.2"

--- a/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
+++ b/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
@@ -33,7 +33,6 @@ class LdapUserProviderSpec extends ObjectBehavior
         $identifier = 'john.doe@example.com';
 
         $interface->getUserInfo($identifier)->shouldBeCalled();
-
         $this->retrieveById($identifier);
     }
 }

--- a/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
+++ b/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
@@ -3,13 +3,14 @@
 namespace spec\Dsdevbe\LdapConnector;
 
 use Dsdevbe\LdapConnector\Adapter\LdapInterface;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 use PhpSpec\ObjectBehavior;
 
 class LdapUserProviderSpec extends ObjectBehavior
 {
-    public function let(LdapInterface $interface)
+    public function let(HasherContract $hasher, LdapInterface $interface)
     {
-        $this->beConstructedWith($interface);
+        $this->beConstructedWith($hasher, $interface);
     }
 
     public function it_is_initializable()

--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -2,37 +2,37 @@
 
 namespace Dsdevbe\LdapConnector\Adapter;
 
-use adLDAP\adLDAP as adLDAPService;
-use adLDAP\collections\adLDAPUserCollection as adLDAPUserCollection;
+use Adldap\Adldap as adLDAPService;
+use Adldap\Models\User as adLDAPUserModel;
 use Dsdevbe\LdapConnector\Model\User as UserModel;
+use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
 class Adldap implements LdapInterface
 {
+
+    /**
+     * @var HasherContract
+     */
+    protected $_hasher;
+
+    /**
+     * @var adLDAPService
+     */
     protected $_ldap;
 
+    /**
+     * @var string
+     */
     protected $_username;
 
+    /**
+     * @var string
+     */
     protected $_password;
 
-    protected function mapDataToUserModel(adLDAPUserCollection $user, array $groups)
+    public function __construct(HasherContract $hasher, array $config)
     {
-        $model = new UserModel([
-            'username' => $user->samaccountname,
-            'password' => $this->_password,
-        ]);
-        $model->setGroups($groups);
-        $model->setUserInfo([
-            'username'  => $user->samaccountname,
-            'firstname' => $user->givenname,
-            'lastname'  => $user->sn,
-            'email'     => $user->mail,
-        ]);
-
-        return $model;
-    }
-
-    public function __construct($config)
-    {
+        $this->_hasher = $hasher;
         $this->_ldap = new adLDAPService($config);
     }
 
@@ -44,35 +44,30 @@ class Adldap implements LdapInterface
      */
     public function connect($username, $password)
     {
-        $this->_username = $username;
-        $this->_password = $password;
-
         return $this->_ldap->authenticate($username, $password);
     }
 
     /**
-     * @return bool
-     */
-    public function isConnected()
-    {
-        return (bool) $this->_ldap->getLdapBind();
-    }
-
-    /**
      * @param string $username
+     * @param string $password
      *
      * @return UserModel
      */
-    public function getUserInfo($username)
+    public function getUserInfo($username, $password = null)
     {
-        $user = $this->_ldap->user()->infoCollection($username, ['samaccountname', 'givenname', 'sn', 'mail']);
+        $user = $this->_ldap->search()->where('samaccountname', '=', $username)->first();
 
-        if (!$user) {
-            return;
-        }
+        return $this->mapDataToUserModel($user, $password);
+    }
 
-        $groups = $this->_ldap->user()->groups($username);
+    protected function mapDataToUserModel(adLDAPUserModel $user, $password)
+    {
+        $model = new UserModel([
+            'username' => $user->getAccountName(),
+            'password' => ($password) ? $this->_hasher->make($password) : null,
+        ]);
+        $model->setUserInfo($user);
 
-        return $this->mapDataToUserModel($user, $groups);
+        return $model;
     }
 }

--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
 class Adldap implements LdapInterface
 {
-
     /**
      * @var HasherContract
      */

--- a/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
@@ -15,10 +15,10 @@ interface LdapInterface
     public function connect($username, $password);
 
     /**
-     * @param string $username
-     * @param string $password
+     * @param $username
+     * @param string|null $password
      *
      * @return UserModel
      */
-    public function getUserInfo($username, $password);
+    public function getUserInfo($username, $password = null);
 }

--- a/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
@@ -15,14 +15,10 @@ interface LdapInterface
     public function connect($username, $password);
 
     /**
-     * @return bool
-     */
-    public function isConnected();
-
-    /**
-     * @param $username
+     * @param string $username
+     * @param string $password
      *
      * @return UserModel
      */
-    public function getUserInfo($username);
+    public function getUserInfo($username, $password);
 }

--- a/src/Dsdevbe/LdapConnector/Exception/MissingConfiguration.php
+++ b/src/Dsdevbe/LdapConnector/Exception/MissingConfiguration.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dsdevbe\LdapConnector\Exception;
+
+use Exception;
+
+class MissingConfiguration extends Exception
+{
+
+}

--- a/src/Dsdevbe/LdapConnector/Exception/MissingConfiguration.php
+++ b/src/Dsdevbe/LdapConnector/Exception/MissingConfiguration.php
@@ -6,5 +6,4 @@ use Exception;
 
 class MissingConfiguration extends Exception
 {
-
 }

--- a/src/Dsdevbe/LdapConnector/LdapConnectorServiceProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapConnectorServiceProvider.php
@@ -4,7 +4,6 @@ namespace Dsdevbe\LdapConnector;
 
 use Auth;
 use Dsdevbe\LdapConnector\Adapter\Adldap;
-use Illuminate\Auth\Guard;
 use Illuminate\Support\ServiceProvider;
 
 class LdapConnectorServiceProvider extends ServiceProvider
@@ -23,13 +22,12 @@ class LdapConnectorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Auth::extend('ldap', function($app) {
+        Auth::provider('ldap', function ($app, array $config) {
             $ldap = new Adldap(
                 $this->getLdapAdapterConfig('adldap')
             );
-            $provider = new LdapUserProvider($ldap);
 
-            return new Guard($provider, $app['session.store']);
+            return new LdapUserProvider($ldap);
         });
     }
 

--- a/src/Dsdevbe/LdapConnector/LdapUserProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapUserProvider.php
@@ -59,7 +59,7 @@ class LdapUserProvider implements UserProviderInterface
      * Update the "remember me" token for the given user in storage.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  string  $token
+     * @param  string                                      $token
      * @return void
      */
     public function updateRememberToken(Authenticatable $user, $token)
@@ -90,7 +90,7 @@ class LdapUserProvider implements UserProviderInterface
      * Validate a user against the given credentials.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  array  $credentials
+     * @param  array                                       $credentials
      * @return bool
      */
     public function validateCredentials(Authenticatable $user, array $credentials)

--- a/src/Dsdevbe/LdapConnector/Model/User.php
+++ b/src/Dsdevbe/LdapConnector/Model/User.php
@@ -2,8 +2,8 @@
 
 namespace Dsdevbe\LdapConnector\Model;
 
-use Illuminate\Contracts\Auth\Authenticatable;
 use Adldap\Models\User as adLDAPUserModel;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class User implements Authenticatable
 {
@@ -28,7 +28,6 @@ class User implements Authenticatable
     protected $_adLDAP;
 
     /**
-     * User constructor.
      * @param array $attributes
      */
     public function __construct(array $attributes)

--- a/src/Dsdevbe/LdapConnector/Model/User.php
+++ b/src/Dsdevbe/LdapConnector/Model/User.php
@@ -3,6 +3,7 @@
 namespace Dsdevbe\LdapConnector\Model;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Adldap\Models\User as adLDAPUserModel;
 
 class User implements Authenticatable
 {
@@ -22,15 +23,14 @@ class User implements Authenticatable
     protected $_rememberToken;
 
     /**
-     * @var array
+     * @var adLDAPUserModel
      */
-    protected $_groups;
+    protected $_adLDAP;
 
     /**
-     * @var array
+     * User constructor.
+     * @param array $attributes
      */
-    protected $_user;
-
     public function __construct(array $attributes)
     {
         $this->_authIdentifier = $attributes['username'];
@@ -95,66 +95,22 @@ class User implements Authenticatable
     }
 
     /**
-     * @return array
+     * @return adLDAPUserModel
      */
-    public function getGroups()
+    public function getAdLDAP()
     {
-        return $this->_groups;
+        return $this->_adLDAP;
     }
 
     /**
-     * @param array $groups
+     * @param adLDAPUserModel $userModel
+     *
+     * @return $this
      */
-    public function setGroups(array $groups)
+    public function setUserInfo(adLDAPUserModel $userModel)
     {
-        $this->_groups = $groups;
-    }
+        $this->_adLDAP = $userModel;
 
-    /**
-     * @return bool
-     */
-    public function inGroup($groupName)
-    {
-        return in_array($groupName, $this->_groups);
-    }
-
-    /**
-     * @param array $user
-     */
-    public function setUserInfo(array $user)
-    {
-        $this->_user = $user;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUsername()
-    {
-        return $this->_user['username'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getFirstname()
-    {
-        return $this->_user['firstname'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getLastname()
-    {
-        return $this->_user['lastname'];
-    }
-
-    /**
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->_user['email'];
+        return $this;
     }
 }

--- a/src/Dsdevbe/LdapConnector/Model/User.php
+++ b/src/Dsdevbe/LdapConnector/Model/User.php
@@ -38,6 +38,16 @@ class User implements Authenticatable
     }
 
     /**
+     * Get the name of the unique identifier for the user.
+     *
+     * @return string
+     */
+    public function getAuthIdentifierName()
+    {
+        return $this->_authIdentifier;
+    }
+
+    /**
      * Get the unique identifier for the user.
      *
      * @return mixed


### PR DESCRIPTION
This is the PR will close #28 and will be the new version of Ldap-connector plugin `4.0.0`

This release contains:
- Laravel 5.2.x support
- Upgrade of [adLDAP2](https://github.com/adLDAP2/adLDAP2) version
- Directly exposing all fields [adLDAP2](https://github.com/adLDAP2/adLDAP2) provides with `Auth::user()->getAdLDAP()`