### PR TITLE
Remove password validation from retrieveByCredentials method in LdapUserProvider

### DIFF
--- a/src/Dsdevbe/LdapConnector/LdapUserProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapUserProvider.php
@@ -80,9 +80,7 @@ class LdapUserProvider implements UserProviderInterface
         $username = $credentials['username'];
         $password = $credentials['password'];
 
-        if ($this->_adapter->connect($username, $password)) {
-            return $this->_adapter->getUserInfo($username, $password);
-        }
+        return $this->_adapter->getUserInfo($username, $password);
     }
 
     /**


### PR DESCRIPTION
`retrieveByCredentials` should return an implantation of `UserInterface` [without attempting to do any password validation or authentication](https://laravel.com/docs/5.2/authentication#adding-custom-user-providers). 

Currently when authenticating the user is logged in twice: once by `retrieveByCredentials` and once by `validateCredentials`. This causes issues with systems like [FreeIPA's one time passwords (OTP)](http://www.freeipa.org/page/V4/OTP) 2FA. `retrieveByCredentials` will use the OTP causing `validateCredentials` to fail.