### PR TITLE
Fix retrieveByCredentials and validateCredentials closes

### DIFF
--- a/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
+++ b/spec/Dsdevbe/LdapConnector/LdapUserProviderSpec.php
@@ -3,14 +3,14 @@
 namespace spec\Dsdevbe\LdapConnector;
 
 use Dsdevbe\LdapConnector\Adapter\LdapInterface;
-use Illuminate\Contracts\Hashing\Hasher as HasherContract;
+use Illuminate\Contracts\Auth\Authenticatable;
 use PhpSpec\ObjectBehavior;
 
 class LdapUserProviderSpec extends ObjectBehavior
 {
-    public function let(HasherContract $hasher, LdapInterface $interface)
+    public function let(LdapInterface $interface)
     {
-        $this->beConstructedWith($hasher, $interface);
+        $this->beConstructedWith($interface);
     }
 
     public function it_is_initializable()
@@ -18,15 +18,25 @@ class LdapUserProviderSpec extends ObjectBehavior
         $this->shouldHaveType('Dsdevbe\LdapConnector\LdapUserProvider');
     }
 
-    public function it_validate_user_by_credentials(LdapInterface $interface)
+    public function it_validate_user_by_credentials()
     {
         $user = [
             'username' => 'john.doe@example.com',
             'password' => 'johnpassdoe',
         ];
 
-        $interface->connect($user['username'], $user['password'])->shouldBeCalled();
         $this->retrieveByCredentials($user);
+    }
+
+    public function it_validate_password_against_ldap(LdapInterface $interface, Authenticatable $user)
+    {
+        $credentials = [
+            'username' => 'john.doe@example.com',
+            'password' => 'johnpassdoe',
+        ];
+
+        $interface->connect($credentials['username'], $credentials['password'])->shouldBeCalled();
+        $this->validateCredentials($user, $credentials);
     }
 
     public function it_retrieves_user_by_id(LdapInterface $interface)

--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -59,6 +59,14 @@ class Adldap implements LdapInterface
         return $this->mapDataToUserModel($user, $password);
     }
 
+    /**
+     * @return bool
+     */
+    public function isConnectedToLdap()
+    {
+        return $this->_ldap->getConnection()->isBound();
+    }
+
     protected function mapDataToUserModel(adLDAPUserModel $user, $password)
     {
         $model = new UserModel([

--- a/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/LdapInterface.php
@@ -21,4 +21,9 @@ interface LdapInterface
      * @return UserModel
      */
     public function getUserInfo($username, $password = null);
+
+    /**
+     * @return bool
+     */
+    public function isConnectedToLdap();
 }

--- a/src/Dsdevbe/LdapConnector/LdapConnectorServiceProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapConnectorServiceProvider.php
@@ -29,7 +29,7 @@ class LdapConnectorServiceProvider extends ServiceProvider
             }
             $ldap = new Adldap($app['hash'], $config['adldap']);
 
-            return new LdapUserProvider($app['hash'], $ldap);
+            return new LdapUserProvider($ldap);
         });
     }
 

--- a/src/Dsdevbe/LdapConnector/LdapUserProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapUserProvider.php
@@ -6,23 +6,17 @@ use Arr;
 use Dsdevbe\LdapConnector\Adapter\LdapInterface;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider as UserProviderInterface;
-use Illuminate\Contracts\Hashing\Hasher as HasherContract;
 
 class LdapUserProvider implements UserProviderInterface
 {
-    /**
-     * @var HasherContract
-     */
-    protected $_hasher;
 
     /**
      * @var LdapInterface;
      */
     protected $_adapter;
 
-    public function __construct(HasherContract $hasher, LdapInterface $adapter)
+    public function __construct(LdapInterface $adapter)
     {
-        $this->_hasher = $hasher;
         $this->_adapter = $adapter;
     }
 
@@ -77,10 +71,12 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function retrieveByCredentials(array $credentials)
     {
-        $username = $credentials['username'];
-        $password = $credentials['password'];
+        if ($this->_adapter->isConnectedToLdap()) {
+            $username = $credentials['username'];
+            $password = $credentials['password'];
 
-        return $this->_adapter->getUserInfo($username, $password);
+            return $this->_adapter->getUserInfo($username, $password);
+        }
     }
 
     /**
@@ -93,6 +89,6 @@ class LdapUserProvider implements UserProviderInterface
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        return $this->_hasher->check($credentials['password'], $user->getAuthPassword());
+        return $this->_adapter->connect($credentials['username'], $credentials['password']);
     }
 }

--- a/src/Dsdevbe/LdapConnector/LdapUserProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapUserProvider.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Auth\UserProvider as UserProviderInterface;
 
 class LdapUserProvider implements UserProviderInterface
 {
-
     /**
      * @var LdapInterface;
      */

--- a/src/Dsdevbe/LdapConnector/LdapUserProvider.php
+++ b/src/Dsdevbe/LdapConnector/LdapUserProvider.php
@@ -80,9 +80,7 @@ class LdapUserProvider implements UserProviderInterface
         $username = $credentials['username'];
         $password = $credentials['password'];
 
-        if ($this->_adapter->connect($username, $password)) {
-            return $this->_adapter->getUserInfo($username, $password);
-        }
+        return $this->_adapter->getUserInfo($username, $password);
     }
 
     /**


### PR DESCRIPTION
The Laravel documentation specify that [Custom User Providers](https://laravel.com/docs/5.2/authentication#adding-custom-user-providers) that the method `retrieveByCredentials` doesn't validate user credentials.

This PR contains the changes to respect the purpose of the methods and closes #35