### PR TITLE
Update Adldap.php to check for failed user search

### DIFF
--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -57,7 +57,7 @@ class Adldap implements LdapInterface
         $user = $this->_ldap->search()->where('samaccountname', '=', $username)->first();
 
         if (!$user) {
-            return null;
+            return;
         }
 
         return $this->mapDataToUserModel($user, $password);

--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -56,6 +56,10 @@ class Adldap implements LdapInterface
     {
         $user = $this->_ldap->search()->where('samaccountname', '=', $username)->first();
 
+        if (!$user) {
+            return null;
+        }
+
         return $this->mapDataToUserModel($user, $password);
     }
 

--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -50,7 +50,7 @@ class Adldap implements LdapInterface
      * @param string $username
      * @param string $password
      *
-     * @return UserModel
+     * @return UserModel|null
      */
     public function getUserInfo($username, $password = null)
     {


### PR DESCRIPTION
If the samaccountname does not exist, the user will be false. The false user is then attempted to pass into mapDataToUserModel which expects an instance of adLDAPUserModel causing an exception to be thrown.

The solution is to check if the user search returns false, if so we can return null.
